### PR TITLE
bugfix, command option names can only be lowercase.

### DIFF
--- a/src/commands/AnnouncementCommand.ts
+++ b/src/commands/AnnouncementCommand.ts
@@ -53,7 +53,7 @@ export default class AnnouncementCommand implements Command {
                     .setRequired(true)
             )
             .addStringOption(option =>
-                option.setName('Minerushing')
+                option.setName('minerushing')
                     .setDescription('Minerushing? (vote/yes/no)')
                     .setRequired(true)
             )


### PR DESCRIPTION
i was receiving some cryptic error that turned out to be from the `Minerushing` option being uppercase. I set it to `minerushing` because all the other ones are lowercase as well.